### PR TITLE
move final UI figure

### DIFF
--- a/paper/sections/implementing.tex
+++ b/paper/sections/implementing.tex
@@ -293,6 +293,15 @@ since we have constrained the types to create type level guarantees.
 \subsection{The user interface}
 \label{user-interface}
 
+\begin{figure*}
+  \noindent\begin{minipage}{\textwidth}
+    \center
+    \includegraphics[width=\textwidth]{assets/final_ui1.png}
+  \end{minipage}\hfill
+  \caption{A tree visualization}
+  \label{fig:final_ui}
+\end{figure*}
+
 The user interface allows for two different visualizations of
 programs: a textual representation and a tree representation. The
 implementation of the textual representation is simple: A conversion
@@ -307,14 +316,6 @@ representation of ASTs. We implemented a function that given an \texttt{Edt}
 returns HTML. An example of an
 editor expression being built is in the upper left corner of the images in
 figure \ref{fig:final_ui}.
-
-\begin{figure*}
-  \begin{center}
-      \includegraphics[width=0.7\textwidth]{assets/final_ui1.png}
- \end{center}
-  \caption{A tree visualization}
-  \label{fig:final_ui}
-\end{figure*}
 
 %%% Local Variables:
 %%% mode: latex


### PR DESCRIPTION
Lige nu er Figur 9 på side 7. Vi er lidt usikre på om det er et problem, men denne PR flytter den lidt op, og så er det kun referencer der kommer ned til side 7. Du "merger" eller ser bort fra den alt efter hvad du synes 😅